### PR TITLE
Fix Spells Deserialization

### DIFF
--- a/src/main/java/safro/archon/api/SpellComponent.java
+++ b/src/main/java/safro/archon/api/SpellComponent.java
@@ -22,13 +22,18 @@ public class SpellComponent implements AutoSyncedComponent {
 
     @Override
     public void readFromNbt(NbtCompound tag) {
+        getSpells().clear();
+
         if (tag.contains("Spells")) {
             NbtList list = tag.getList("Spells", NbtElement.COMPOUND_TYPE);
 
             for (int i = 0; i < list.size(); i++) {
                 NbtCompound nbt = list.getCompound(i);
                 Spell s = SpellRegistry.REGISTRY.get(new Identifier(nbt.getString("Spell")));
-                getSpells().add(s);
+
+                if (!getSpells().contains(s)) {
+                    getSpells().add(s);
+                }
             }
         }
     }


### PR DESCRIPTION
The `SpellComponent` doesn't clean itself up when deserializing causing issues with mods that modify and re-write player data. The spell list ends up doubling in size every save until the server can't start anymore. This should resolve it. :)